### PR TITLE
6 imessagecontent use should always call

### DIFF
--- a/billpg.pop3svc.Tests/IPBanEngineTests.cs
+++ b/billpg.pop3svc.Tests/IPBanEngineTests.cs
@@ -41,7 +41,7 @@ namespace billpg.pop3svc.Tests
                 ban.RegisterFailedAttempt(ip);
 
                 /* After three attempts (0,1,2), this IP is banned. */
-                Assert.AreEqual(attemptCount > 2, ban.IsBanned(ip));
+                Assert.AreEqual(attemptCount > 1, ban.IsBanned(ip));
             }
         }
     }

--- a/billpg.pop3svc/CommandHandler.cs
+++ b/billpg.pop3svc/CommandHandler.cs
@@ -339,7 +339,7 @@ namespace billpg.pop3svc
 
             /* If RETR, return the whole message without a wrapper. */
             if (lineCountSend < 0)
-                return PopResponse.OKMulti("Message text follows...", msg.NextLine);
+                return PopResponse.OKMulti("Message text follows...", ContentWrappers.WrapForRetr(msg));
 
             /* If TOP (include header but stop early. */
             else

--- a/billpg.pop3svc/ContentWrappers.cs
+++ b/billpg.pop3svc/ContentWrappers.cs
@@ -26,22 +26,28 @@ namespace billpg.pop3svc
 
             /* Raise a flag once Close has been called. */
             bool calledClose = false;
+            void CloseStream()
+            {
+                /* Notthing to do if closed already called. */
+                if (calledClose)
+                    return;
 
+                /* Inform the message content object. */
+                msg.Close();
+
+                /* Raise the flag. */
+                calledClose = true;
+            }
+
+            /* Return he wrapper function. */
             return Impl;
             string Impl()
             {
                 /* Have we exhausted the requested line count? */
                 if (lineCount == 0)
                 {
-                    /* Inform the message content object we're stopping. */
-                    if (calledClose == false)
-                    {
-                        /* Actually call Close. */
-                        msg.Close();
-
-                        /* Raise flag to prevent repeat. */
-                        calledClose = true;
-                    }
+                    /* Inform the content object and raise flag. */
+                    CloseStream();
 
                     /* Signal end-of-stream. */
                     return null;
@@ -50,7 +56,11 @@ namespace billpg.pop3svc
                 /* Load a line. Test for end-of-message. */
                 string line = msg.NextLine();
                 if (line == null)
+                {
+                    /* Close the message content stream and return null. */
+                    CloseStream();
                     return null;
+                }
 
                 /* Is it the blank line that ends the header? */
                 if (insideMesageBody == false && line.Length == 0)

--- a/billpg.pop3svc/ContentWrappers.cs
+++ b/billpg.pop3svc/ContentWrappers.cs
@@ -10,6 +10,12 @@ namespace billpg.pop3svc
 {
     internal static class ContentWrappers
     {
+        /// <summary>
+        /// Wrap a message content interface with a NextLineFn function suiatbe for a TOP command.
+        /// </summary>
+        /// <param name="msg">Provider's message content object.</param>
+        /// <param name="lineCount">Numbe rof lines after the ehader.</param>
+        /// <returns>Wrapper function.</returns>
         internal static NextLineFn WrapForTop(IMessageContent msg, long lineCount)
         {
             /* Update counter, because the blank line doesn't count. */
@@ -55,6 +61,41 @@ namespace billpg.pop3svc
                     lineCount -= 1;
 
                 /* Return the line. */
+                return line;
+            }
+        }
+
+        /// <summary>
+        /// Wrap a message content object in a NextLineFn wrapper.
+        /// </summary>
+        /// <param name="msg">Provider's messge content object.</param>
+        /// <returns>Wrapped function instance.</returns>
+        internal static NextLineFn WrapForRetr(IMessageContent msg)
+        {
+            /* Setup a flag to be raised when the message content has completed. */
+            bool endOfMessage = false;
+
+            /* Return the wrapper function. */
+            return Wrap;
+            string Wrap()
+            {
+                /* If we've already seen the end of the message, return null only. */
+                if (endOfMessage)
+                    return null;
+
+                /* Read the next line from the supplied object. */
+                string line = msg.NextLine();
+
+                /* End of message? */
+                if (line == null)
+                {
+                    /* Close the wrapped resource, raise flag and stop. */
+                    msg.Close();
+                    endOfMessage = true;
+                    return null;                    
+                }
+
+                /* Otherwise, return loaded line. */
                 return line;
             }
         }


### PR DESCRIPTION
- Modify RETR to stream lines through a wrapper that will call Close.
- Modify TOP's wrapper to call close when the message ends before the line count.
- Fix a unit test. *Three* strikes and you're banned.